### PR TITLE
README: Fix heading notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Graphical intuition to MOSFET square-law
+### Graphical intuition to MOSFET square-law
 
 Modify those variables to get respective graphs
 ```python


### PR DESCRIPTION
It wasn't displayed as a heading